### PR TITLE
Relax WS message size limit.

### DIFF
--- a/src/com/carolinarollergirls/scoreboard/jetty/WS.java
+++ b/src/com/carolinarollergirls/scoreboard/jetty/WS.java
@@ -192,6 +192,9 @@ public class WS extends WebSocketServlet {
         @Override
         public void onOpen(Connection connection) {
             connectionsActive.inc();
+            // Some messages can be bigger than the 16k default
+            // when there is broad registration.
+            connection.setMaxTextMessageSize(1024 * 1024);
             this.connection = connection;
             id = UUID.randomUUID();
             jsm.register(this);


### PR DESCRIPTION
This was causing problems such as:

2019-04-01 21:42:02.415:WARN:oejw.WebSocketConnectionRFC6455:Text
message too large > 16384 chars for
SCEP@36de1067{l(/127.0.0.1:55418)<->r(/127.0.0.1:8000),s=1,open=true,ishut=false,oshut=false,rb=false,wb=false,w=true,i=1r}-{WebSocketServletConnectionRFC6455
p=WebSocketParserRFC6455@375f6afb state=DATA buffer=
g=WebSocketGeneratorRFC6455@3e651079 closed=false buffer=-1}


Let me know if this handle the slow load issue also.